### PR TITLE
Lidar bugfixes, build improvements, and refactoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ jar {
     }
 }
 
-task LidarTest(type: Jar) {
+task lidarTest(type: Jar) {
     baseName "LidarTest"
     from configurations.lidarLibs.collect { it.isDirectory() ? it : zipTree(it) }
     manifest {

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,8 @@ repositories {
 }
 
 configurations  {
-    appLibs  // config to hold jars to include in an app jar
+    lidarLibs  // config to hold jars to include in an app jar
+    pathWebappLibs
 }
 
 apply plugin: 'org.junit.platform.gradle.plugin'
@@ -52,41 +53,44 @@ deploy {
 }
 
 wpi {
-    // We use a newer version than default one for 2018
+    // We use a newer version than the default one for 2018
     ctreVersion = "5.3.1.0"
 }
 
-// Defining my dependencies. In this case, WPILib (+ friends), CTRE Toolsuite (Talon SRX)
-// and NavX.
+// Defining my dependencies. In this case, WPILib (+ friends), CTRE Toolsuite (Talon SRX),
+// and deps for spring/lidar websockets (lidar standalone app)/path webapp
 dependencies {
-    compile 'org.java-websocket:Java-WebSocket:1.3.9'
     compile wpilib()
     compile ctre()
     compile("gov.nist.math:jama:1.0.3")
     testCompile("org.junit.jupiter:junit-jupiter-api:5.0.3")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:5.0.3")
 
-    appLibs group: "org.java-websocket", name: "Java-WebSocket", version:"1.3.9"
+    compile ("org.java-websocket:Java-WebSocket:1.3.9")
+    lidarLibs group: "org.java-websocket", name: "Java-WebSocket", version:"1.3.9"
 
-    // Path webapp: XXX: should these be migrated outside our deployed jar?
     def tomcatVersion = '7.0.57'
-    tomcat "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}",
-            "org.apache.tomcat.embed:tomcat-embed-logging-juli:${tomcatVersion}"
-    tomcat("org.apache.tomcat.embed:tomcat-embed-jasper:${tomcatVersion}") {
+    tomcat ("org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}")
+    tomcat ("org.apache.tomcat.embed:tomcat-embed-logging-juli:${tomcatVersion}")
+    tomcat ("org.apache.tomcat.embed:tomcat-embed-jasper:${tomcatVersion}") {
         exclude group: 'org.eclipse.jdt.core.compiler', module: 'ecj'
     }
-    compile("org.springframework:spring-webmvc:4.3.0.RELEASE")
-    compile("javax.servlet:javax.servlet-api:3.0.1")
-    compile("javax.servlet:jstl:1.2") 
+
+    compile ("org.springframework:spring-webmvc:4.3.0.RELEASE")
+    compile ("javax.servlet:javax.servlet-api:3.0.1")
+    compile ("javax.servlet:jstl:1.2")
+    pathWebappLibs group: "org.springframework", name: "spring-webmvc", version: "4.3.0.RELEASE"
+    pathWebappLibs group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+    pathWebappLibs group: "javax.servlet", name: "jstl", version: "1.2"
 }
 
 // context where tomcat is deployed, by default localhost:8080/
 tomcatRun.contextPath = '/'
 tomcatRunWar.contextPath = '/'
 
-// Setting up my Jar File. In this case, adding all libraries into the main jar ('fat jar')
-// in order to make them all available at runtime. Also adding the manifest so WPILib
-// knows where to look for our Robot Class.
+// Setting up my Jar File. In this case, adding all libraries (except path/lidar standalone
+// build libs) into the main jar ('fat jar') in order to make them all available at runtime.
+// Also adding the manifest so WPILib knows where to look for our Robot Class.
 jar {
     from configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
     manifest {
@@ -105,14 +109,25 @@ jar {
         )
     }
     manifest jaci.openrio.gradle.GradleRIOPlugin.javaManifest(ROBOT_CLASS)
+    from(sourceSets.main.output) {
+        exclude "com/spartronics4915/lidar/**"
+        exclude "com/spartronics4915/path/**"
+    }
 }
 
 task LidarTest(type: Jar) {
     baseName "LidarTest"
-    from configurations.appLibs.collect { it.isDirectory() ? it : zipTree(it) }
+    from configurations.lidarLibs.collect { it.isDirectory() ? it : zipTree(it) }
     manifest {
         attributes "Main-Class": "com.spartronics4915.lidar.LidarMain"
     }
+    from(sourceSets.main.output) {
+        exclude "com/spartronics4915/frc*/**"
+    }
+}
+
+tomcatRunWar << {
+    from configurations.pathWebappLibs.collect { it.isDirectory() ? it : zipTree(it) }
     from(sourceSets.main.output) {
         exclude "com/spartronics4915/frc*/**"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ dependencies {
 
     appLibs group: "org.java-websocket", name: "Java-WebSocket", version:"1.3.9"
 
-    // Path webapp: XXX: should tese be migrated outside our deployed jar?
+    // Path webapp: XXX: should these be migrated outside our deployed jar?
     def tomcatVersion = '7.0.57'
     tomcat "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}",
             "org.apache.tomcat.embed:tomcat-embed-logging-juli:${tomcatVersion}"
@@ -111,7 +111,7 @@ task LidarTest(type: Jar) {
     baseName "LidarTest"
     from configurations.appLibs.collect { it.isDirectory() ? it : zipTree(it) }
     manifest {
-        attributes "Main-Class": "com.spartronics4915.lib.apps.LidarMain"
+        attributes "Main-Class": "com.spartronics4915.lidar.LidarMain"
     }
     from(sourceSets.main.output) {
         exclude "com/spartronics4915/frc*/**"

--- a/src/main/java/com/spartronics4915/frc2019/Robot.java
+++ b/src/main/java/com/spartronics4915/frc2019/Robot.java
@@ -92,7 +92,8 @@ public class Robot extends IterativeRobot
                 mDrive = Drive.getInstance();
                 mLidarProcessor = new LidarProcessor(LidarProcessor.RunMode.kRunInRobot,
                                         null,
-                                        null
+                                        null,
+                                        () -> Timer.getFPGATimestamp()
                                 );
                 // mTurret = Turret.getInstance(); TODO: Uncomment when turret is added
 

--- a/src/main/java/com/spartronics4915/frc2019/subsystems/RobotStateEstimator.java
+++ b/src/main/java/com/spartronics4915/frc2019/subsystems/RobotStateEstimator.java
@@ -4,6 +4,9 @@ import com.spartronics4915.frc2019.Constants;
 import com.spartronics4915.frc2019.Kinematics;
 import com.spartronics4915.frc2019.RobotState;
 import com.spartronics4915.lib.util.ILooper;
+
+import edu.wpi.first.wpilibj.Timer;
+
 import com.spartronics4915.lib.util.ILoop;
 import com.spartronics4915.lib.geometry.Rotation2d;
 import com.spartronics4915.lib.geometry.Twist2d;
@@ -32,7 +35,8 @@ public class RobotStateEstimator extends Subsystem
          */
         mLidarProcessor = new LidarProcessor(LidarProcessor.RunMode.kRunInRobot, 
                             Constants.kSegmentReferenceModel,
-                            robot_state_/*IPose2dMap*/);
+                            robot_state_/*IRobotStateMap*/,
+                            () -> Timer.getFPGATimestamp());
     }
 
     @Override

--- a/src/main/java/com/spartronics4915/lib/lidar/LidarPoint.java
+++ b/src/main/java/com/spartronics4915/lib/lidar/LidarPoint.java
@@ -40,8 +40,7 @@ class LidarPoint
                                               Math.sin(radians) * this.distance);
         if(robotPose != null)
         {
-            robotPose.transformBy(Pose2d.fromTranslation(x2d));
-            return robotPose.getTranslation();
+            return robotPose.transformBy(Pose2d.fromTranslation(x2d)).getTranslation();
         }
         else
             return x2d;

--- a/src/main/java/com/spartronics4915/lib/lidar/LidarProcessor.java
+++ b/src/main/java/com/spartronics4915/lib/lidar/LidarProcessor.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.DoubleSupplier;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.zip.GZIPOutputStream;
 
@@ -127,6 +128,7 @@ public class LidarProcessor implements ILoop
     private WSClient mWSClient;
     private IReferenceModel mReferenceModel;
     private IRobotStateMap mStateMap;
+    private DoubleSupplier mTimeSupplier;
 
     // A scan is a collection of lidar points.  The scan, itself,
     // has a timestamp as does each point.  Currently, the timestamp
@@ -152,7 +154,7 @@ public class LidarProcessor implements ILoop
     };
 
     public LidarProcessor(RunMode runMode, IReferenceModel refmodel,
-        IRobotStateMap stateMap) 
+        IRobotStateMap stateMap, DoubleSupplier timeSupplier) 
     {
         Logger.debug("LidarProcessor starting...");
         mICP = new ICP(100);
@@ -167,6 +169,7 @@ public class LidarProcessor implements ILoop
         mActiveScan = null;
         mReferenceModel = refmodel; // may be null
         mStateMap = stateMap;
+        mTimeSupplier = timeSupplier;
 
         try 
         {
@@ -363,7 +366,7 @@ public class LidarProcessor implements ILoop
                 mScanQueue.add(mActiveScan); // <- send it to consumer
 
             mActiveScan  = new LidarScan();
-            startNewScan(System.currentTimeMillis() / 1000d);
+            startNewScan(mTimeSupplier.getAsDouble());
         }
         if (!excludePoint(cartesian.x(), cartesian.y())) 
         {

--- a/src/main/java/com/spartronics4915/lib/util/Logger.java
+++ b/src/main/java/com/spartronics4915/lib/util/Logger.java
@@ -3,6 +3,7 @@ package com.spartronics4915.lib.util;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.file.Paths;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -79,8 +80,10 @@ public class Logger
 
     public static void exception(Exception e)
     {
-        logMarker("EXCEPT  " + e.getMessage() +
-                " trace:\n" +  e.getStackTrace());
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+        logMarker("EXCEPT  " + e.getMessage() + 
+            " trace:\n" + sw.toString());
     }
 
     public static void error(String m)

--- a/src/main/java/com/spartronics4915/lidar/LidarMain.java
+++ b/src/main/java/com/spartronics4915/lidar/LidarMain.java
@@ -1,6 +1,6 @@
 package com.spartronics4915.lidar;
 
-import com.spartronics4915.lib.util.Looper;
+import com.spartronics4915.lidar.Looper;
 import com.spartronics4915.lib.util.Logger;
 import com.spartronics4915.lib.util.InterpolatingDouble;
 import com.spartronics4915.lib.util.InterpolatingTreeMap;
@@ -25,12 +25,26 @@ public class LidarMain
         mLooper.register(mLidarProcessor);
         boolean started = mLidarProcessor.isConnected();
         if(!started)
+        {
+            Logger.error("Lidar is not connected");
             return;
+        }
+
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                synchronized (mLooper) {
+                    mLooper.stop();
+                    Runtime.getRuntime().halt(0); // System::exit will wait on this thread to finish
+                }
+            }
+        });
 
         Pose2d zeroPose = new Pose2d();
         double ts = System.currentTimeMillis() / 1000d;
         sPoses.put(new InterpolatingDouble(ts), zeroPose);
         mLooper.start();
+
         while (true)
         {
             try

--- a/src/main/java/com/spartronics4915/lidar/LidarMain.java
+++ b/src/main/java/com/spartronics4915/lidar/LidarMain.java
@@ -21,7 +21,7 @@ public class LidarMain
 
         mLooper = new Looper();
         mLidarProcessor = new LidarProcessor(LidarProcessor.RunMode.kRunAsTest,
-                                            null, null);
+                                null, null, () -> System.currentTimeMillis() / 1000d);
         mLooper.register(mLidarProcessor);
         boolean started = mLidarProcessor.isConnected();
         if(!started)

--- a/src/main/java/com/spartronics4915/lidar/LidarMain.java
+++ b/src/main/java/com/spartronics4915/lidar/LidarMain.java
@@ -1,6 +1,4 @@
-package com.spartronics4915.lib.apps;
-
-import java.util.concurrent.TimeUnit;
+package com.spartronics4915.lidar;
 
 import com.spartronics4915.lib.util.Looper;
 import com.spartronics4915.lib.util.Logger;

--- a/src/main/java/com/spartronics4915/lidar/Looper.java
+++ b/src/main/java/com/spartronics4915/lidar/Looper.java
@@ -1,25 +1,15 @@
-package com.spartronics4915.lib.util;
+package com.spartronics4915.lidar;
 
 import com.spartronics4915.lib.util.CrashTrackingRunnable;
 import com.spartronics4915.lib.util.Logger;
 import com.spartronics4915.lib.util.ILooper;
 import com.spartronics4915.lib.util.ILoop;
-import com.spartronics4915.lib.util.InterpolatingDouble;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-
-//import com.spartronics4915.lib.util.Logger;
 
 /**
  * This code runs all of the robot's loops. ILoop objects are stored in a List
@@ -104,7 +94,7 @@ public class Looper implements ILooper
         if (running_)
         {
             Logger.notice("Looper stopping subsystem loops");
-            scheduler_.shutdown();
+            scheduler_.shutdownNow();
             synchronized (taskRunningLock_)
             {
                 running_ = false;


### PR DESCRIPTION
 * There were a couple of bugs with the absolute lidar mode that are fixed here.
 * Webapp dependencies are no longer packaged in the robot-bound jar.
 * The `LidarMain` has been moved to `com.spartronics4915.lidar`.
 * We don't mix and match time methods anymore.